### PR TITLE
Feature/data read improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.tab
-
+*sampling_key.csv
 Results/
 
 __pycache__/

--- a/reader.py
+++ b/reader.py
@@ -1,10 +1,11 @@
 import pandas as pd
 import os
 
-def read_file(filepath, excel, sheet, columns, tab_file_path):
-    input_sheet = pd.read_excel(filepath + "/" +excel, sheet, skiprows=2)
+def read_file(excelfile, sheet, columns, tab_file_path, filename, skipheaders=0):
+    #input_sheet = pd.read_excel(filepath + "/" +excel, sheet, skiprows=2)
 
-    data_table = input_sheet.iloc[:, columns]
+    input_sheet = excelfile[sheet]
+    data_table = input_sheet.iloc[skipheaders:, columns]
     data_table.columns = pd.Series(data_table.columns).str.replace(' ', '_')
     data_nonempty = data_table.dropna()
 
@@ -16,14 +17,15 @@ def read_file(filepath, excel, sheet, columns, tab_file_path):
         os.makedirs(tab_file_path)
     #excel = excel.replace(".xlsx", "_")
     #excel = excel.replace("Excel/", "")
-    save_csv_frame.to_csv(tab_file_path + "/" + excel.replace(".xlsx", '_') + sheet + '.tab', header=True, index=None, sep='\t', mode='w')
+    save_csv_frame.to_csv(tab_file_path + "/" + filename + "_" + sheet + '.tab', header=True, index=None, sep='\t', mode='w')
     #save_csv_frame.to_csv(excel.replace(".xlsx", '_') + sheet + '.tab', header=True, index=None, sep='\t', mode='w')
 
-def read_sets(filepath, excel, sheet, tab_file_path):
-    input_sheet = pd.read_excel(filepath + "/" + excel, sheet)
+def read_sets(excelfile, sheet, tab_file_path, filename, skipheaders=0):
+    
+    input_sheet = excelfile[sheet]
 
     for ind, column in enumerate(input_sheet.columns):
-        data_table = input_sheet.iloc[:, ind]
+        data_table = input_sheet.iloc[0:, ind]
         data_nonempty = data_table.dropna()
         data_nonempty.replace(" ", "")
         save_csv_frame = pd.DataFrame(data_nonempty)
@@ -32,7 +34,7 @@ def read_sets(filepath, excel, sheet, tab_file_path):
             os.makedirs(tab_file_path)
         #excel = excel.replace(".xlsx", "_")
         #excel = excel.replace("Excel/", "")
-        save_csv_frame.to_csv(tab_file_path + "/" + excel.replace(".xlsx", '_') + column + '.tab', header=True, index=None, sep='\t', mode='w')
+        save_csv_frame.to_csv(tab_file_path + "/" + filename + "_" + column + '.tab', header=True, index=None, sep='\t', mode='w')
         #save_csv_frame.to_csv(excel.replace(".xlsx", '_') + column + '.tab', header=True, index=None, sep='\t', mode='w')
 
 def generate_tab_files(filepath, tab_file_path):
@@ -47,69 +49,75 @@ def generate_tab_files(filepath, tab_file_path):
     if not os.path.exists(tab_file_path):
         os.makedirs(tab_file_path)
 
-    read_sets(filepath, 'Sets.xlsx', 'Nodes', tab_file_path = tab_file_path)
-    read_sets(filepath, 'Sets.xlsx', 'Horizon', tab_file_path = tab_file_path)
-    read_sets(filepath, 'Sets.xlsx', 'LineType', tab_file_path = tab_file_path)
-    read_sets(filepath, 'Sets.xlsx', 'Technology', tab_file_path = tab_file_path)
-    read_sets(filepath, 'Sets.xlsx', 'Storage', tab_file_path = tab_file_path)
-    read_sets(filepath, 'Sets.xlsx', 'Generators', tab_file_path = tab_file_path)
-    read_file(filepath, 'Sets.xlsx', 'StorageOfNodes', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Sets.xlsx', 'GeneratorsOfNode', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Sets.xlsx', 'GeneratorsOfTechnology', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Sets.xlsx', 'DirectionalLines', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Sets.xlsx', 'LineTypeOfDirectionalLines', [0, 1, 2], tab_file_path = tab_file_path)
+    SetsExcelData = pd.read_excel(filepath + "/Sets.xlsx", sheet_name=None)
+    read_sets(SetsExcelData, 'Nodes', tab_file_path, "Sets")
+    read_sets(SetsExcelData, 'Horizon', tab_file_path, "Sets")
+    read_sets(SetsExcelData, 'LineType', tab_file_path, "Sets")
+    read_sets(SetsExcelData, 'Technology', tab_file_path, "Sets")
+    read_sets(SetsExcelData, 'Storage', tab_file_path, "Sets")
+    read_sets(SetsExcelData, 'Generators', tab_file_path, "Sets")
+    read_file(SetsExcelData, 'StorageOfNodes', [0, 1], tab_file_path, "Sets", skipheaders=2)
+    read_file(SetsExcelData, 'GeneratorsOfNode', [0, 1], tab_file_path, "Sets", skipheaders=2)
+    read_file(SetsExcelData, 'GeneratorsOfTechnology', [0, 1], tab_file_path, "Sets", skipheaders=2)
+    read_file(SetsExcelData, 'DirectionalLines', [0, 1], tab_file_path, "Sets", skipheaders=2)
+    read_file(SetsExcelData, 'LineTypeOfDirectionalLines', [0, 1, 2], tab_file_path, "Sets", skipheaders=2)
 
     # Reading GeneratorPeriod
-    read_file(filepath, 'Generator.xlsx', 'FixedOMCosts', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'CapitalCosts', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'VariableOMCosts', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'FuelCosts', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'CCSCostTSVariable', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'Efficiency', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'RefInitialCap', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'ScaleFactorInitialCap', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'InitialCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'MaxBuiltCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'MaxInstalledCapacity', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'RampRate', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'GeneratorTypeAvailability', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'CO2Content', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Generator.xlsx', 'Lifetime', [0, 1], tab_file_path = tab_file_path)
+    GeneratorExcelData = pd.read_excel(filepath + "/Generator.xlsx", sheet_name=None)
+    read_file(GeneratorExcelData, 'FixedOMCosts', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'CapitalCosts', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'VariableOMCosts', [0, 1], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'FuelCosts', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'CCSCostTSVariable', [0, 1], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'Efficiency', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'RefInitialCap', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'ScaleFactorInitialCap', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'InitialCapacity', [0, 1, 2, 3], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'MaxBuiltCapacity', [0, 1, 2, 3], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'MaxInstalledCapacity', [0, 1, 2], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'RampRate', [0, 1], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'GeneratorTypeAvailability', [0, 1], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'CO2Content', [0, 1], tab_file_path, "Generator", skipheaders=2)
+    read_file(GeneratorExcelData, 'Lifetime', [0, 1], tab_file_path, "Generator", skipheaders=2)
 
     #Reading InterConnector
-    read_file(filepath, 'Transmission.xlsx', 'lineEfficiency', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'MaxInstallCapacityRaw', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'MaxBuiltCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'Length', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'TypeCapitalCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'TypeFixedOMCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'InitialCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Transmission.xlsx', 'Lifetime', [0, 1, 2], tab_file_path = tab_file_path)
+    TransmissionExcelData = pd.read_excel(filepath + "/Transmission.xlsx", sheet_name=None)
+    read_file(TransmissionExcelData, 'lineEfficiency', [0, 1, 2], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'MaxInstallCapacityRaw', [0, 1, 2, 3], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'MaxBuiltCapacity', [0, 1, 2, 3], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'Length', [0, 1, 2], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'TypeCapitalCost', [0, 1, 2], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'TypeFixedOMCost', [0, 1, 2], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'InitialCapacity', [0, 1, 2, 3], tab_file_path,  "Transmission", skipheaders=2)
+    read_file(TransmissionExcelData, 'Lifetime', [0, 1, 2], tab_file_path,  "Transmission", skipheaders=2)
 
     #Reading Node
-    read_file(filepath, 'Node.xlsx', 'ElectricAnnualDemand', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Node.xlsx', 'NodeLostLoadCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Node.xlsx', 'HydroGenMaxAnnualProduction', [0, 1], tab_file_path = tab_file_path)
+    NodeExcelData = pd.read_excel(filepath + "/Node.xlsx", sheet_name=None)
+    read_file(NodeExcelData , 'ElectricAnnualDemand', [0, 1, 2],tab_file_path,  "Node", skipheaders=2)
+    read_file(NodeExcelData , 'NodeLostLoadCost', [0, 1, 2],tab_file_path,  "Node", skipheaders=2)
+    read_file(NodeExcelData , 'HydroGenMaxAnnualProduction', [0, 1],tab_file_path,  "Node", skipheaders=2)
 
     #Reading Season
-    read_file(filepath, 'General.xlsx', 'seasonScale', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'General.xlsx', 'CO2Cap', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'General.xlsx', 'CO2Price', [0, 1], tab_file_path = tab_file_path)
+    GeneralExcelData = pd.read_excel(filepath + "/General.xlsx", sheet_name=None)
+    read_file(GeneralExcelData, 'seasonScale', [0, 1], tab_file_path, "General", skipheaders=2)
+    read_file(GeneralExcelData, 'CO2Cap', [0, 1], tab_file_path, "General", skipheaders=2)
+    read_file(GeneralExcelData, 'CO2Price', [0, 1], tab_file_path, "General", skipheaders=2)
     
     #Reading Storage
-    read_file(filepath, 'Storage.xlsx', 'StorageBleedEfficiency', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'StorageChargeEff', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'StorageDischargeEff', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'StoragePowToEnergy', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'StorageInitialEnergyLevel', [0, 1], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'InitialPowerCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'PowerCapitalCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'PowerFixedOMCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'PowerMaxBuiltCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'EnergyCapitalCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'EnergyFixedOMCost', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'EnergyInitialCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'EnergyMaxBuiltCapacity', [0, 1, 2, 3], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'EnergyMaxInstalledCapacity', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'PowerMaxInstalledCapacity', [0, 1, 2], tab_file_path = tab_file_path)
-    read_file(filepath, 'Storage.xlsx', 'Lifetime', [0, 1], tab_file_path = tab_file_path)
+    StorageExcelData = pd.read_excel(filepath + "/Storage.xlsx", sheet_name=None)
+    read_file(StorageExcelData, 'StorageBleedEfficiency', [0, 1], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'StorageChargeEff', [0, 1], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'StorageDischargeEff', [0, 1], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'StoragePowToEnergy', [0, 1], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'StorageInitialEnergyLevel', [0, 1], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'InitialPowerCapacity', [0, 1, 2, 3], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'PowerCapitalCost', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'PowerFixedOMCost', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'PowerMaxBuiltCapacity', [0, 1, 2, 3], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'EnergyCapitalCost', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'EnergyFixedOMCost', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'EnergyInitialCapacity', [0, 1, 2, 3], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'EnergyMaxBuiltCapacity', [0, 1, 2, 3], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'EnergyMaxInstalledCapacity', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'PowerMaxInstalledCapacity', [0, 1, 2], tab_file_path, "Storage", skipheaders=2)
+    read_file(StorageExcelData, 'Lifetime', [0, 1], tab_file_path, "Storage", skipheaders=2)

--- a/scenario_random.py
+++ b/scenario_random.py
@@ -491,6 +491,11 @@ def generate_random_scenario(filepath, tab_file_path, scenarios, seasons,
     hydroSeasonal = hydroSeasonal[["Node", "Period", "Season", 
                                    "Operationalhour", "Scenario",
                                    "HydroGeneratorMaxSeasonalProduction"]]
+    
+    genAvail.loc[genAvail["GeneratorStochasticAvailabilityRaw"] <= 0.001,"GeneratorStochasticAvailabilityRaw"] = 0
+    elecLoad.loc[elecLoad['ElectricLoadRaw_in_MW'] <= 0.001,'ElectricLoadRaw_in_MW'] = 0
+    hydroSeasonal.loc[hydroSeasonal["HydroGeneratorMaxSeasonalProduction"] <= 0.001,"HydroGeneratorMaxSeasonalProduction"] = 0
+    
 
     #Make filepath (if it does not exist) and print .tab-files
     if not os.path.exists(tab_file_path):


### PR DESCRIPTION
Made changes to reader.py so that the excel input files are only loaded once per file by panadas. 

Also, I've introduced a clipping of stochastic data to reduce the number of small values in the constraint coefficient matrix. Currently all stochastic data are clipped at 0.001 (i.e set to zero). This means for instance that a 1 GW onshore wind resource in a node would never be able to deliver less than 1 MW, even if the underlying wind data from the scenario generation suggests that it technically should. I expect the impact on results to be negligible. 