### PR TITLE
Add configurable Gurobi solver options and reformulate emission cap for performance

### DIFF
--- a/config/run.yaml
+++ b/config/run.yaml
@@ -28,3 +28,16 @@ serialize_instance: False                              # Serialize the data stru
 north_sea: True                                        # Whether the north sea is modelled or not
 leap_years_investment: 5                               # Number of years per period (default: 5)
 time_format: "%d/%m/%Y %H:%M"                          # Time format for scenario data files
+use_ramping: True                                      # Include thermal ramp-rate constraints. Set False to drop inter-hour coupling for thermal units (faster, but only if ramping is non-binding)
+
+# Solver (Gurobi) performance options. Leave a value commented/absent to use the Gurobi default.
+# Speed: these are the accelerators — use them for large runs.
+solver_method: 2                                       # 2 = barrier (interior point), best for large LPs
+solver_crossover: 0                                    # 0 = skip crossover (it cost 9-10x the barrier time in past runs); duals/prices become interior approximations — set -1 or remove for exact basic prices
+solver_presolve: -1                                    # -1 = automatic (Gurobi default); set 2 for aggressive presolve to shrink the matrix on large LPs
+# solver_threads: 16                                     # Set to the PHYSICAL core count of the machine the run executes on; avoids hyperthread/NUMA contention
+# Robustness (brakes, not accelerators): each of these makes Gurobi SLOWER. Only enable
+# one at a time if a run fails with numerical-trouble messages — never preemptively.
+# solver_scaleflag: 2                                    # 2 = aggressive matrix scaling (-1=auto, 0=off); scales the matrix only, not the objective
+# solver_numericfocus: 1                                 # 1-3 = progressively more numerical care (progressively slower)
+# solver_barhomogeneous: 1                               # 1 = homogeneous barrier variant for ill-conditioned/infeasible models (slower)

--- a/empire/core/config.py
+++ b/empire/core/config.py
@@ -48,6 +48,14 @@ class EmpireConfiguration:
         len_peak_season: int = 24,
         leap_years_investment: int = 5,
         time_format: str = "%d/%m/%Y %H:%M",
+        use_ramping: bool = True,
+        solver_method: int = 2,
+        solver_crossover: int | None = None,
+        solver_presolve: int | None = -1,
+        solver_threads: int | None = None,
+        solver_scaleflag: int | None = None,
+        solver_numericfocus: int | None = None,
+        solver_barhomogeneous: int | None = None,
         **kwargs,
     ):
         """
@@ -79,6 +87,22 @@ class EmpireConfiguration:
         :param n_peak_seasons:  Peak seasons.
         :param leap_years_investment: Years between investment decisions
         :param time_format: Time format
+        :param use_ramping: If true (default), thermal generator ramp-rate constraints are included. Setting it to
+            false removes the inter-hour ramping constraints (fewer rows, less temporal coupling for thermal units);
+            only do this if ramping is non-binding at your time resolution, as it is a physical modelling assumption.
+        :param solver_method: Gurobi 'Method' parameter (algorithm). 2 = barrier, best for large LPs.
+        :param solver_crossover: Gurobi 'Crossover' parameter. 0 skips the crossover tail for faster
+            barrier solves (interior-point solution only; duals/prices become approximate). None leaves the solver default.
+        :param solver_presolve: Gurobi 'Presolve' parameter. -1 = automatic (default), 0 = off,
+            1 = conservative, 2 = aggressive. None leaves the option unset.
+        :param solver_threads: Gurobi 'Threads' parameter (max threads). Cap at physical core count to avoid
+            hyperthread/NUMA contention on multi-socket machines. None leaves the solver default (all logical cores).
+        :param solver_scaleflag: Gurobi 'ScaleFlag' parameter (matrix scaling). 0=off, 1/2/3 increasingly aggressive,
+            -1=auto. Scaling is internal; results are returned in original units. None leaves the solver default.
+        :param solver_numericfocus: Gurobi 'NumericFocus' parameter. 0=auto, 1-3 spend more effort on numerical
+            accuracy (recommended when reading interior-point duals with crossover off). None leaves the solver default.
+        :param solver_barhomogeneous: Gurobi 'BarHomogeneous' parameter. 1 enables the homogeneous barrier variant,
+            more robust on ill-conditioned models. None leaves the solver default (-1, auto).
         """
         # Model parameters
         self.use_temporary_directory = use_temporary_directory
@@ -116,6 +140,16 @@ class EmpireConfiguration:
         self.len_peak_season = len_peak_season
         self.leap_years_investment = leap_years_investment
         self.time_format = time_format
+        self.use_ramping = use_ramping
+
+        # Solver (Gurobi) performance options
+        self.solver_method = solver_method
+        self.solver_crossover = solver_crossover
+        self.solver_presolve = solver_presolve
+        self.solver_threads = solver_threads
+        self.solver_scaleflag = solver_scaleflag
+        self.solver_numericfocus = solver_numericfocus
+        self.solver_barhomogeneous = solver_barhomogeneous
 
         # Computed attributes
         self.n_reg_season = len(regular_seasons)

--- a/empire/core/empire.py
+++ b/empire/core/empire.py
@@ -19,8 +19,13 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
                solver, temp_dir, FirstHoursOfRegSeason, FirstHoursOfPeakSeason, lengthRegSeason,
                lengthPeakSeason, Period, Operationalhour, Scenario, Season, HoursOfSeason,
                discountrate, WACC, LeapYearsInvestment, IAMC_PRINT, WRITE_LP,
-               PICKLE_INSTANCE, EMISSION_CAP, USE_TEMP_DIR, LOADCHANGEMODULE, OPERATIONAL_DUALS, north_sea, 
-               OUT_OF_SAMPLE: bool = False, sample_file_path: Path | None = None) -> None | float:
+               PICKLE_INSTANCE, EMISSION_CAP, USE_TEMP_DIR, LOADCHANGEMODULE, OPERATIONAL_DUALS, north_sea,
+               OUT_OF_SAMPLE: bool = False, sample_file_path: Path | None = None,
+               RAMPING: bool = True,
+               solver_method: int = 2, solver_crossover: int | None = None,
+               solver_presolve: int | None = -1, solver_threads: int | None = None,
+               solver_scaleflag: int | None = None, solver_numericfocus: int | None = None,
+               solver_barhomogeneous: int | None = None) -> None | float:
 
     if USE_TEMP_DIR:
         TempfileManager.tempdir = temp_dir
@@ -600,15 +605,18 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
 
     #################################################################
 
-    def ramping_rule(model, n, g, h, i, w):
-        if h in model.FirstHoursOfRegSeason or h in model.FirstHoursOfPeakSeason:
-            return Constraint.Skip
-        else:
-            if g in model.ThermalGenerators:
-                return model.genOperational[n,g,h,i,w]-model.genOperational[n,g,(h-1),i,w] - model.genRampUpCap[g]*model.genInstalledCap[n,g,i] <= 0   #
-            else:
+    if RAMPING:
+        def ramping_rule(model, n, g, h, i, w):
+            if h in model.FirstHoursOfRegSeason or h in model.FirstHoursOfPeakSeason:
                 return Constraint.Skip
-    model.ramping = Constraint(model.GeneratorsOfNode, model.Operationalhour, model.PeriodActive, model.Scenario, rule=ramping_rule)
+            else:
+                if g in model.ThermalGenerators:
+                    return model.genOperational[n,g,h,i,w]-model.genOperational[n,g,(h-1),i,w] - model.genRampUpCap[g]*model.genInstalledCap[n,g,i] <= 0   #
+                else:
+                    return Constraint.Skip
+        model.ramping = Constraint(model.GeneratorsOfNode, model.Operationalhour, model.PeriodActive, model.Scenario, rule=ramping_rule)
+    else:
+        logger.info("Ramping constraints disabled (use_ramping=False)...")
 
     #################################################################
 
@@ -696,9 +704,20 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
     #################################################################
 
     if EMISSION_CAP:
+        # Emissions are accumulated per node (in tonnes CO2) before being summed in the cap.
+        # A single cap row over all generators x hours is a dense row that causes severe
+        # fill-in in the barrier solver, and the former /1e6 (Mt) scaling put 5e-8
+        # coefficients in the matrix. Domain is Reals: CCS generators can have negative
+        # CO2 factors and the cap itself goes negative in later periods.
+        model.nodeEmission = Var(model.Node, model.PeriodActive, model.Scenario, domain=Reals)
+
+        def node_emission_rule(model, n, i, w):
+            return sum(model.seasScale[s]*model.genCO2TypeFactor[g]*(3.6/model.genEfficiency[g,i])*model.genOperational[n,g,h,i,w] for g in model.Generator if (n,g) in model.GeneratorsOfNode for (s,h) in model.HoursOfSeason) \
+                - model.nodeEmission[n,i,w] == 0
+        model.node_emission = Constraint(model.Node, model.PeriodActive, model.Scenario, rule=node_emission_rule)
+
         def emission_cap_rule(model, i, w):
-            return sum(model.seasScale[s]*model.genCO2TypeFactor[g]*(3.6/model.genEfficiency[g,i])*model.genOperational[n,g,h,i,w] for (n,g) in model.GeneratorsOfNode for (s,h) in model.HoursOfSeason)/1000000 \
-                - model.CO2cap[i] <= 0   #
+            return sum(model.nodeEmission[n,i,w] for n in model.Node) - 1e6*model.CO2cap[i] <= 0   #
         model.emission_cap = Constraint(model.PeriodActive, model.Scenario, rule=emission_cap_rule)
 
     #################################################################
@@ -887,8 +906,20 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
         #instance.display('outputs_xpress.txt')
     if solver == "Gurobi":
         opt = SolverFactory('gurobi', Verbose=True)
-        opt.options["Crossover"]=0
-        opt.options["Method"]=2
+        opt.options["Method"] = solver_method          # 2 = barrier (interior point), best for large LPs
+        if solver_crossover is not None:
+            opt.options["Crossover"] = solver_crossover  # 0 = skip crossover tail (interior solution only)
+        if solver_presolve is not None:
+            opt.options["Presolve"] = solver_presolve    # 2 = aggressive presolve to shrink the matrix
+        if solver_threads is not None:
+            opt.options["Threads"] = solver_threads      # cap at physical cores to avoid hyperthread/NUMA contention
+        if solver_scaleflag is not None:
+            opt.options["ScaleFlag"] = solver_scaleflag      # matrix scaling (internal; results returned in original units)
+        if solver_numericfocus is not None:
+            opt.options["NumericFocus"] = solver_numericfocus  # 1-3: more effort on numerical accuracy (helps interior duals)
+        if solver_barhomogeneous is not None:
+            opt.options["BarHomogeneous"] = solver_barhomogeneous  # 1: robust barrier variant for ill-conditioned models
+        logger.info("Gurobi options: %s", dict(opt.options))
     if solver == "GLPK":
         opt = SolverFactory("glpk", Verbose=True)
 
@@ -1146,7 +1177,7 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
             my_string=[inv_per[int(i-1)],w, 
             value(sum(instance.seasScale[s]*instance.genOperational[n,g,h,i,w]*instance.genCO2TypeFactor[g]*(3.6/instance.genEfficiency[g,i]) for (n,g) in instance.GeneratorsOfNode for (s,h) in instance.HoursOfSeason))]
             if EMISSION_CAP:
-                my_string.extend([value(instance.dual[instance.emission_cap[i,w]]/(instance.operationalDiscountrate*instance.sceProbab[w]*1e6)),value(instance.CO2cap[i]*1e6)])
+                my_string.extend([value(instance.dual[instance.emission_cap[i,w]]/(instance.operationalDiscountrate*instance.sceProbab[w])),value(instance.CO2cap[i]*1e6)])
             else:
                 my_string.extend([value(instance.CO2price[i]),0])
             my_string.extend([value(sum(instance.seasScale[s]*instance.genOperational[n,g,h,i,w]/1000 for (n,g) in instance.GeneratorsOfNode for (s,h) in instance.HoursOfSeason)), 
@@ -1447,12 +1478,14 @@ def run_empire(name, tab_file_path: Path, result_file_path: Path, scenario_data_
 
         f = open(result_file_path / 'results_co2_price_resolved.csv', 'w', newline='')
         writer = csv.writer(f)
-        writer.writerow(["Period","Scenario","AnnualCO2emission_Ton","CO2Price_EuroPerTon"])
+        writer.writerow(["Period","Scenario","AnnualCO2emission_Ton","CO2Price_EuroPerTon","CO2Cap_Ton"])
         for i in instance.PeriodActive:
             for w in instance.Scenario:
-                my_string=[inv_per[int(i-1)],w, 
+                my_string=[inv_per[int(i-1)],w,
                 value(sum(instance.seasScale[s]*instance.genOperational[n,g,h,i,w]*instance.genCO2TypeFactor[g]*(3.6/instance.genEfficiency[g,i]) for (n,g) in instance.GeneratorsOfNode for (s,h) in instance.HoursOfSeason))]
                 if EMISSION_CAP:
-                    my_string.extend([value(instance.dual[instance.emission_cap[i,w]]/(instance.operationalDiscountrate*instance.sceProbab[w]*1e6)),value(instance.CO2cap[i]*1e6)])
+                    my_string.extend([value(instance.dual[instance.emission_cap[i,w]]/(instance.operationalDiscountrate*instance.sceProbab[w])),value(instance.CO2cap[i]*1e6)])
                 else:
                     my_string.extend([value(instance.CO2price[i]),0])
+                writer.writerow(my_string)
+        f.close()

--- a/empire/core/model_runner.py
+++ b/empire/core/model_runner.py
@@ -147,8 +147,16 @@ def run_empire_model(
             LOADCHANGEMODULE=empire_config.load_change_module,
             OPERATIONAL_DUALS=empire_config.compute_operational_duals,
             north_sea=empire_config.north_sea,
-            OUT_OF_SAMPLE=OUT_OF_SAMPLE, 
-            sample_file_path=sample_file_path
+            OUT_OF_SAMPLE=OUT_OF_SAMPLE,
+            sample_file_path=sample_file_path,
+            RAMPING=empire_config.use_ramping,
+            solver_method=empire_config.solver_method,
+            solver_crossover=empire_config.solver_crossover,
+            solver_presolve=empire_config.solver_presolve,
+            solver_threads=empire_config.solver_threads,
+            solver_scaleflag=empire_config.solver_scaleflag,
+            solver_numericfocus=empire_config.solver_numericfocus,
+            solver_barhomogeneous=empire_config.solver_barhomogeneous,
             )
 
     config_path = run_config.dataset_path / "config.txt"


### PR DESCRIPTION


Make the Gurobi performance parameters configurable from run.yaml instead of hard-coding them, add a toggle to disable thermal ramping constraints, and reformulate the emission cap so it solves efficiently with the barrier method.

Solver configuration (config.py, model_runner.py, empire.py, run.yaml):
- New EmpireConfiguration / run.yaml options: use_ramping plus solver_method, solver_crossover, solver_presolve, solver_threads, solver_scaleflag, solver_numericfocus and solver_barhomogeneous. Each solver_* option is only applied when set, otherwise the Gurobi default is left untouched.
- use_ramping=False drops the inter-hour thermal ramping constraints (fewer rows, less temporal coupling); defaults to True to preserve current behaviour.

Emission cap reformulation (empire.py):
- Accumulate emissions per node into an auxiliary variable (tonnes CO2) and sum those in the cap, replacing a single dense cap row whose 1/1e6 scaling produced ~5e-8 matrix coefficients and severe fill-in in the barrier solver.
- Drop the matching 1e6 factor when recovering the CO2 price from the cap dual.
- Fix results_co2_price_resolved.csv, which previously wrote a header but no rows; also add the CO2 cap column to both CO2 price outputs.

## Backward compatibility
Defaults reproduce current behaviour (`use_ramping=True`, `solver_method=2`). The
emission-cap reformulation is mathematically equivalent to the original; only the
matrix scaling and the (equivalent) dual recovery change.